### PR TITLE
feat: adding custom enterprise styling file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules
 resources/
 themes/
 public/
+.hugo_build.lock
+go.sum
 
 # Yarn Berry
 yarn-error.log

--- a/assets/_sass/_custom_enterprise.scss
+++ b/assets/_sass/_custom_enterprise.scss
@@ -1,0 +1,1 @@
+// Don't remove, this file is the default

--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -1,23 +1,23 @@
 // Optional variable overrides
-@import "_sass/default-variables";
-@import "_sass/variables";
+@import '_sass/default-variables';
+@import '_sass/variables';
 
 //Core CSS
-@import "_sass/bootstrap/";
-@import "_sass/navbar";
-@import "_sass/structure";
-@import "_sass/editor";
-@import "_sass/image";
-@import "_sass/syntax";
-@import "_sass/tooltips";
-@import "_sass/home";
-@import "_sass/print";
-
+@import '_sass/bootstrap/';
+@import '_sass/navbar';
+@import '_sass/structure';
+@import '_sass/editor';
+@import '_sass/image';
+@import '_sass/syntax';
+@import '_sass/tooltips';
+@import '_sass/print';
 
 // Optional custom CSS loaded last
-@import "_sass/variables";
-@import "_sass/default-fonts";
-@import "_sass/fonts";
-@import "_sass/custom";
-@import "_sass/pdf";
-@import "_sass/mermaid";
+@import '_sass/variables';
+@import '_sass/default-fonts';
+@import '_sass/fonts';
+@import '_sass/custom';
+@import '_sass/custom_enterprise';
+@import '_sass/local';
+@import '_sass/pdf';
+@import '_sass/mermaid';

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/spandigital/presidium-styling-base
 
-go 1.23.0
+go 1.18


### PR DESCRIPTION
Added a `custom_enterprise.scss` file, because if a docset has a `custom.scss` file it replaces the `custom.scss` file meant to be organization level custom styling.
