### PR TITLE
fix: PRSDM-7301 span handbook numbered lists arent expanded and its not intuitive that the list is expandable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## 2025-01-23
+
 ### Feature
+
 - github action to auto generate semantic release for main.
 - added pr title linting from https://github.com/SPANDigital/presidium-theme-website/commit/e940f801c5d29bcc479c3f6cc17b5b95ac2ef30d
 - updated readme
-@Quantumplate [PRSDM-7228](https://spandigital.atlassian.net/browse/PRSDM-7228)
+  @Quantumplate [PRSDM-7228](https://spandigital.atlassian.net/browse/PRSDM-7228)
+
+## 2025-02-18
+
+### Bugfix
+
+- Fixed an issue where summary tags were not displaying a dropdown arrow. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-7301

--- a/assets/_sass/components/_components.scss
+++ b/assets/_sass/components/_components.scss
@@ -1,0 +1,2 @@
+// Presidium System Defined Components
+@import 'article/';

--- a/assets/_sass/components/article/_article.scss
+++ b/assets/_sass/components/article/_article.scss
@@ -1,0 +1,1 @@
+@import 'lists';

--- a/assets/_sass/components/article/_lists.scss
+++ b/assets/_sass/components/article/_lists.scss
@@ -1,0 +1,3 @@
+summary {
+  display: list-item;
+}

--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -3,6 +3,7 @@
 @import '_sass/default-typography';
 @import '_sass/variables';
 @import '_sass/bootstrap/';
+@import '_sass/components/';
 @import '_sass/navbar';
 @import '_sass/structure';
 @import '_sass/editor';


### PR DESCRIPTION
## Description
Fixed an issue with lists using summary tags which weren't displaying a dropdown arrow/indicator

## Issue
- [x] :clipboard: [JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-7301)

## Screenshots
![Screenshot 2025-02-18 at 09 55 43](https://github.com/user-attachments/assets/93030f32-29ce-410a-a78d-8fef88f487b2)

## Test
1. Ensure you have opened this branch in `presidium-styling-base`
2. Open `span-handbook-docs` using `develop` branch and point the theme to your local layout module (See [Hugo Crash Course](https://docs.spandigital.net/docs/presidium-docs-internal/hugo-crash-course/#first-steps-with-hugo-themes))
3. In `span-handbook-docs` run `make refresh` followed by `make serve`
4. Go to http://localhost:1313/career-development/ and check that the issue is fixed

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
