### PR TITLE
fix: remove bootstrap minified import to be added to styling repo

### DIFF
--- a/assets/presidium.scss
+++ b/assets/presidium.scss
@@ -1,8 +1,12 @@
-//Core System level CSS
+// Core System level CSS
 @import '_sass/default-variables';
 @import '_sass/default-typography';
 @import '_sass/variables';
-@import '_sass/bootstrap/';
+@import '_sass/bootstrap/bootstrap/variables';
+.content-wrapper {
+  @import '_sass/bootstrap/bootstrap';
+  @import '../../static/assets/css/bootstrap.min.css';
+}
 @import '_sass/components/';
 @import '_sass/navbar';
 @import '_sass/structure';


### PR DESCRIPTION
## Description
remove bootstrap minified import to be added to styling repo
## Issue
- [x] :clipboard:https://spandigital.atlassian.net/browse/PRSDM-7515

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
