### PR TITLE
fix: PRSDM-7645 - Remove orange underline from Presidium Enterprise toolbar links

### DIFF
--- a/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
+++ b/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
@@ -36,8 +36,8 @@ textarea {
 
 
 // Links
-
-a {
+// Commented out links styling to prevent orange underline text decoration leaking into Presidium Enterprise toolbar links.
+/* a {
   color: $link-color;
   text-decoration: none;
 
@@ -50,7 +50,7 @@ a {
   &:focus {
     @include tab-focus;
   }
-}
+} */
 
 
 // Figures

--- a/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
+++ b/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
@@ -34,25 +34,6 @@ textarea {
   line-height: inherit;
 }
 
-
-// Links
-// Commented out links styling to prevent orange underline text decoration leaking into Presidium Enterprise toolbar links.
-/* a {
-  color: $link-color;
-  text-decoration: none;
-
-  &:hover,
-  &:focus {
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
-  }
-
-  &:focus {
-    @include tab-focus;
-  }
-} */
-
-
 // Figures
 //
 // We reset this here because previously Normalize had no `figure` margins. This


### PR DESCRIPTION
## Description
This PR addresses a styling issue where an orange underline was appearing on the toolbar menu links in Presidium Enterprise when loading a module. The style was leaking from presidium-styling-base, specifically from Bootstrap’s `_scaffolding.scss`.

Commented out the specific link decoration rule causing the issue.

**Notes**
- This fix only addresses the link styling issue. The font leakage from presidium-styling-base remains unresolved.
- That issue needs to be addressed through the application of the `span-style-base` theme to modules (see related [ticket](https://spandigital.atlassian.net/browse/PRSDM-7101)).

## Issue
- [PRSDM-7645](https://spandigital.atlassian.net/browse/PRSDM-7645)

## Screenshots
Before:
<img width="295" alt="Screenshot 2025-05-08 at 4 51 06 p m" src="https://github.com/user-attachments/assets/6a5f52cd-0068-49e3-9d3b-a67285c07329" />


After:
<img width="230" alt="Screenshot 2025-05-08 at 6 25 32 p m" src="https://github.com/user-attachments/assets/d914dd6e-ab76-4b60-8cb7-b86cd01c68a6" />


## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
