### PR TITLE
Removed article tag left-padding

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -514,7 +514,7 @@
   }
   
   ul {
-    padding-left: 40px;
+    padding-left: 0;
   }
   
   ol {


### PR DESCRIPTION
## Description
- Removed unwanted padding left of tags, visible on articles and the landing page of Chronicle

## Issue
- [ ] :clipboard: https://spandigital.atlassian.net/browse/PRSDM-8241

## Screenshots
![Screenshot 2025-06-03 at 09 58 19](https://github.com/user-attachments/assets/1e390009-3574-4cb2-9c9f-f9217a500487)
![Screenshot 2025-06-03 at 09 58 30](https://github.com/user-attachments/assets/ea889553-4dbe-40df-bf31-fb4a6760d369)
