### PR TITLE
fix: update tooltips.scss to remove remaining duplicate styles

### DIFF
--- a/assets/_sass/components/article/_tooltips.scss
+++ b/assets/_sass/components/article/_tooltips.scss
@@ -55,18 +55,11 @@ $tooltip-triangle-top: -20%;
     margin-left: -100%;
     z-index: $zindex-popover;
     transition: $tooltip-animation;
-    transition: $tooltip-animation;
-    transition: $tooltip-animation;
-    transition: $tooltip-animation;
-    transition: $tooltip-animation;
     overflow: auto;
     max-height: 76px;
   }
 
   &:hover .tooltips-text {
-    transition-delay: $tooltip-hover-delay;
-    transition-delay: $tooltip-hover-delay;
-    transition-delay: $tooltip-hover-delay;
     transition-delay: $tooltip-hover-delay;
     visibility: visible;
     overflow-y: $tooltip-y-overflow;
@@ -78,9 +71,6 @@ $tooltip-triangle-top: -20%;
     text-decoration: none;
 
     &::after {
-      transition-delay: $tooltip-hover-delay;
-      transition-delay: $tooltip-hover-delay;
-      transition-delay: $tooltip-hover-delay;
       transition-delay: $tooltip-hover-delay;
       visibility: visible;
     }


### PR DESCRIPTION
## Description
Removes duplicate styling which was missed on the initial PR clean up https://github.com/SPANDigital/presidium-styling-base/pull/74


## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
