### PR TITLE
fix: PRSDM-10396 (Truncate brand name to prevent layout shift when space is constrained)

### DIFF
--- a/assets/_sass/components/title-bar/_structure.scss
+++ b/assets/_sass/components/title-bar/_structure.scss
@@ -32,6 +32,10 @@
       margin: 0;
       color: #111827;
       line-height: 41px;
+      // Truncate brand name to prevent layout shift when space is constrained
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .quality-category-labels {

--- a/assets/_sass/components/title-bar/_structure.scss
+++ b/assets/_sass/components/title-bar/_structure.scss
@@ -29,7 +29,7 @@
     .brand-name {
       font-size: 1.25rem;
       font-weight: $font-weight-medium;
-      margin: 0;
+      margin: 0 1rem 0 0;
       color: #111827;
       line-height: 41px;
       // Truncate brand name to prevent layout shift when space is constrained


### PR DESCRIPTION
## Description

Resolve the document title from wrapping in mobile view (when screen width becomes smaller).


## Issue
- [ ] :clipboard: JIRA_TICKET_URL https://spandigital.atlassian.net/browse/PRSDM-10396

## How to test

* Before publish Hugo module:
* Use desktop view first, then resize to mobile
* Note issue

### Test with branch

* Update to use this branch with replace in the go.mod
  * `replace ../presidium-styling-base => /Users/span/workspace/06_presidium/presidium-styling-base`
* Re-publish
* Repeat both desktop then mobile resize, issue resolved

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
