### PR TITLE
feat: implement max content width in module

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -151,9 +151,11 @@
   }
 
   #presidium-content {
-    padding: 20px 40px 40px;
+    padding: 20px 0 40px;
     width: 100%;
     height: 100%;
+    margin: auto;
+    max-width: 720px;
     min-width: 375px;
 
     .article-title {

--- a/assets/_sass/bootstrap/bootstrap/mixins/_grid.scss
+++ b/assets/_sass/bootstrap/bootstrap/mixins/_grid.scss
@@ -4,11 +4,19 @@
 
 // Centered container element
 @mixin container-fixed($gutter: $grid-gutter-width) {
-  margin-right: auto;
-  margin-left: auto;
+  margin-right: 12px;
+  margin-left: 12px;
   padding-left:  floor(($gutter / 2));
   padding-right: ceil(($gutter / 2));
   @include clearfix;
+
+  @media (min-width: $screen-md-min) {
+    margin: 0 20px;
+  }
+
+  @media (min-width: $screen-lg-min) {
+    margin: 0 32px;
+  }
 }
 
 // Creates a wrapper for a series of columns

--- a/assets/_sass/components/blog/home-page/_home-page.scss
+++ b/assets/_sass/components/blog/home-page/_home-page.scss
@@ -62,8 +62,7 @@
 
 .featured-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(258px, 1fr));
-  grid-gap: 32px;
+  grid-template-columns: repeat(3, minmax(240px, 1fr));
 
   @media (max-width: $screen-xlg) {
     grid-template-columns: repeat(2, minmax(258px, 1fr));

--- a/assets/_sass/defaults/_default-typography.scss
+++ b/assets/_sass/defaults/_default-typography.scss
@@ -10,7 +10,7 @@
 // Base
 $prsdm-typography-default-font-color: $color-grey-1 !default;
 $prsdm-typography-secondary-font-color: $color-grey-2 !default;
-$prsdm-typography-base-font-family: 'Open Sans' !default;
+$prsdm-typography-base-font-family: 'Open Sans', sans-serif !default;
 $prsdm-typography-base-font-weight: 400 !default;
 $prsdm-typography-base-line-height: 18px !default;
 $prsdm-typography-base-font-size: 13px !default;


### PR DESCRIPTION
## Description
Implemented a max width constraint to the content in modules as well as responsive horizontal margins. Also added a font fallback to prevent that "Times New Roman" flash of text during loading.

## How to test
1. Open a module e.g. (SPAN Handbook or Chronicle) go to the `go.mod` file and on the last line add:
```
replace github.com/spandigital/presidium-styling-base => <Location of presidium-styling-base>
e.g replace github.com/spandigital/presidium-styling-base => /Users/work/presidium-styling-base
```
2. Run `hugo serve`
3. Go to http://localhost:1313

## Issue
- [ ] :clipboard: [JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-10640)

## Screenshots

https://github.com/user-attachments/assets/7d73a07f-2a06-4bc1-8a9c-893085888775

https://github.com/user-attachments/assets/77d6d9ab-74f1-4900-9906-4fa5f27a01f0


