### PR TITLE
refactor: reinforce styling against tailwind

### DIFF
--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -541,6 +541,7 @@
 
   ul,
   ol {
+    list-style-type: revert;
     padding-left: 40px;
   }
 

--- a/assets/_sass/components/left-nav/_structure.scss
+++ b/assets/_sass/components/left-nav/_structure.scss
@@ -238,6 +238,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
         list-style: none;
         padding-left: 0;
         float: none;
+        visibility: initial;
 
         li {
           cursor: pointer;


### PR DESCRIPTION
## Description
In the process of updating Enterprise to use Tailwind, it was observed that lists (ordered and unordered) and elements in the left nav were affected. Updating these styles prevent these elements from being affected by Tailwind.

**Unordered lists:**
<img width="2560" height="779" alt="Screenshot 2026-05-21 at 15 55 54" src="https://github.com/user-attachments/assets/c4b6913b-4115-410e-84e9-fe3279ff03da" />

**Ordered lists:**
<img width="2560" height="738" alt="Screenshot 2026-05-21 at 22 40 32" src="https://github.com/user-attachments/assets/887fed4d-6897-4c4d-b8eb-20217a60b8c6" />

**Callout lists:**
<img width="2533" height="625" alt="Screenshot 2026-05-21 at 19 33 53" src="https://github.com/user-attachments/assets/32490e5f-2c6e-4bc7-aa9b-682e4986125d" />

## Issue
- [ ] :clipboard: [JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-10900)

## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
