### PR TITLE
fix: remove outdated outline style

### DIFF
--- a/assets/_sass/bootstrap/bootstrap/_buttons.scss
+++ b/assets/_sass/bootstrap/bootstrap/_buttons.scss
@@ -20,15 +20,6 @@
   @include button-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $line-height-base, $btn-border-radius-base);
   @include user-select(none);
 
-  &,
-  &:active,
-  &.active {
-    &:focus,
-    &.focus {
-      @include tab-focus;
-    }
-  }
-
   &:hover,
   &:focus,
   &.focus {

--- a/assets/_sass/bootstrap/bootstrap/_forms.scss
+++ b/assets/_sass/bootstrap/bootstrap/_forms.scss
@@ -70,13 +70,6 @@ select[size] {
   height: auto;
 }
 
-// Focus for file, radio, and checkbox
-input[type="file"]:focus,
-input[type="radio"]:focus,
-input[type="checkbox"]:focus {
-  @include tab-focus;
-}
-
 // Adjust output element
 output {
   display: block;

--- a/assets/_sass/bootstrap/bootstrap/_mixins.scss
+++ b/assets/_sass/bootstrap/bootstrap/_mixins.scss
@@ -10,7 +10,6 @@
 @import "mixins/resize";
 @import "mixins/responsive-visibility";
 @import "mixins/size";
-@import "mixins/tab-focus";
 @import "mixins/reset-text";
 @import "mixins/text-emphasis";
 @import "mixins/text-overflow";

--- a/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
+++ b/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
@@ -46,10 +46,6 @@ a {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;
   }
-
-  &:focus {
-    @include tab-focus;
-  }
 }
 
 

--- a/assets/_sass/bootstrap/bootstrap/mixins/_tab-focus.scss
+++ b/assets/_sass/bootstrap/bootstrap/mixins/_tab-focus.scss
@@ -1,9 +1,0 @@
-// WebKit-style focus
-
-@mixin tab-focus() {
-  // WebKit-specific. Other browsers will keep their default outline style.
-  // (Initially tried to also force default via `outline: initial`,
-  // but that seems to erroneously remove the outline in Firefox altogether.)
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
-}


### PR DESCRIPTION
## Description
Removed the old outline styling as this is making Presidium look outdated and was interfering with Enterprise styling

## Test
Using Chrome, go into a module and click on the elements displayed in the screenshots:

<img width="530" height="260" alt="Screenshot 2026-05-12 at 14 21 06" src="https://github.com/user-attachments/assets/17363867-7cd7-44e6-ad6a-878ce37fe772" />

<img width="546" height="257" alt="Screenshot 2026-05-12 at 14 21 18" src="https://github.com/user-attachments/assets/f671c813-5b8a-4003-a5a9-3d187e272d21" />

<img width="265" height="167" alt="Screenshot 2026-05-12 at 14 21 28" src="https://github.com/user-attachments/assets/20b5f9d7-ca9d-420f-a7fa-3a2a2c7ebc97" />

<img width="1440" height="783" alt="Screenshot 2026-05-19 at 14 39 07" src="https://github.com/user-attachments/assets/b2810049-d40b-417d-b5e6-0cbad3386571" />


## Issue
- [ ] :clipboard: [JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-10943)

## Screenshots

https://github.com/user-attachments/assets/323fc1fe-aad4-4a5e-892e-0c2192e43b67



## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
