### PR TITLE
fix: menu icon styling, layout width, added toolbar border, list bullet consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,9 @@
 ### Bugfix
 
 - Fixed a bug where when searching from within a module, the search filters on the left render below the left navigation. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11071
+
+## 2025-06-26
+
+### Bugfix
+
+- Fixed styling of the menu icon, enforced full width layout and added border to toolbar to help prevent flickering when the toolbar loads. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-10689

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,4 +35,4 @@
 
 ### Bugfix
 
-- Fixed styling of the menu icon, enforced full width layout and added border to toolbar to help prevent flickering when the toolbar loads. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-10689
+- Fixed menu icon styling, enforced a full-width layout, and added a bottom border to the toolbar to help prevent flickering when the toolbar loads. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-10689

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -422,6 +422,10 @@ body {
             display: flex;
           }
 
+          li p {
+            margin-bottom: 0;
+          }
+
           &::before {
             display: flex;
             font-weight: 500;

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -23,14 +23,22 @@
   }
 }
 
+html {
+  display: flex;
+}
+
+body {
+  flex: 1;
+}
+
 #presidium {
   display: flex;
   flex-flow: row;
   flex-direction: column;
 
   .toolbar-wrapper {
+    border-bottom: 1px solid var(--gray-200);
     min-height: 50px;
-    background-color: $color-dark-grey;
     z-index: $zindex-navbar-fixed;
     position: sticky;
     top: 0;
@@ -43,26 +51,14 @@
         display: none;
       }
 
-      width: 30px;
+      width: 48px;
+      padding-inline: 12px;
       top: 16px;
       left: 20px;
       z-index: 1;
       background-color: white;
       border-width: 0px;
-      border-bottom: 1px solid #3d3d3d;
       background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
-
-      .icon-bar {
-        background-color: #777;
-        display: block;
-        width: 22px;
-        height: 2px;
-        border-radius: 1px;
-      }
-
-      .icon-bar + .icon-bar {
-        margin-top: 4px;
-      }
     }
 
     .presidium-enterprise {


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

## Jira tickets
https://spandigital.atlassian.net/browse/PRSDM-10689
https://spandigital.atlassian.net/browse/PRSDM-10231

## What does this PR do?
- Fixes the menu icon styling
- Fixes list bullet consistency
- Enforces the layout width especially for mobile screen sizes
- Added a bottom border to the toolbar to reduce the toolbar flickering when a page loads

## Why is this change needed?
The old version execution was incorrect

## Related PR
https://github.com/SPANDigital/presidium-layouts-base/pull/114

## How to test
Open module in mobile view and observe the menu icon

## Screenshots/Video (optional)

https://github.com/user-attachments/assets/7ac40030-2cd9-4447-89f8-6db4c2828eab
