### PR TITLE
feat: PRSDM-11353 initial implementation of dark mode with update to module title bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,4 +41,4 @@
 
 ### Feature
 
-- Initial implemenation of dark mode and updated the module title bar to support dark mode @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11353
+- Initial implementation of dark mode and updated the module title bar to support dark mode @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11353

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,9 @@
 ### Bugfix
 
 - Fixed menu icon styling, enforced a full-width layout, and added a bottom border to the toolbar to help prevent flickering when the toolbar loads. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-10689
+
+## 2026-07-28
+
+### Feature
+
+- Initial implemenation of dark mode and updated the module title bar to support dark mode @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11353

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -29,6 +29,11 @@ html {
 
 body {
   flex: 1;
+
+  &.dark,
+  .dark & {
+    background: var(--background, black);
+  }
 }
 
 #presidium {
@@ -36,8 +41,13 @@ body {
   flex-flow: row;
   flex-direction: column;
 
+  &.dark,
+  .dark & {
+    background: var(--background, black);
+  }
+
   .toolbar-wrapper {
-    border-bottom: 1px solid var(--gray-200);
+    border-bottom: 1px solid var(--border, $border);
     min-height: 50px;
     z-index: $zindex-navbar-fixed;
     position: sticky;
@@ -56,7 +66,7 @@ body {
       top: 16px;
       left: 20px;
       z-index: 1;
-      background-color: white;
+      background-color: var(--background, white);
       border-width: 0px;
       background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
     }
@@ -64,19 +74,24 @@ body {
     .presidium-enterprise {
       width: 100%;
       height: 50px;
-      background-color: white;
+      background-color: var(--background, white);
     }
   }
 
   .content-wrapper {
     display: flex;
     position: relative;
+
+    &.dark,
+    .dark & {
+      background: var(--background, black);
+    }
   }
 }
 
 #presidium-container {
     .dark & {
-      background: black;
+      background: var(--background, black);
     }
 
   flex-basis: 0;
@@ -100,7 +115,7 @@ body {
     color: $primary-font-color;
 
     .dark & {
-      color: white;
+      color: var(--foreground, white);
     }
   }
 

--- a/assets/_sass/_structure.scss
+++ b/assets/_sass/_structure.scss
@@ -75,6 +75,10 @@ body {
 }
 
 #presidium-container {
+    .dark & {
+      background: black;
+    }
+
   flex-basis: 0;
   flex-grow: 999;
   color: $primary-font-color;
@@ -94,6 +98,10 @@ body {
   h6,
   p {
     color: $primary-font-color;
+
+    .dark & {
+      color: white;
+    }
   }
 
   h1 {

--- a/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
+++ b/assets/_sass/bootstrap/bootstrap/_scaffolding.scss
@@ -20,7 +20,6 @@ body {
   font-family: $primary-font-family;
   font-size: $font-size-base;
   line-height: $line-height-base;
-  color: $text-color;
   background-color: $body-bg;
 }
 

--- a/assets/_sass/components/left-nav/_structure.scss
+++ b/assets/_sass/components/left-nav/_structure.scss
@@ -39,6 +39,10 @@ $nav-item-border: darken($navbar-default-bg, 8%);
 }
 
 #presidium-navigation {
+  .dark & {
+    background: black;
+  }
+
   background: white;
   min-width: 300px;
   max-width: 600px;

--- a/assets/_sass/components/left-nav/_structure.scss
+++ b/assets/_sass/components/left-nav/_structure.scss
@@ -39,11 +39,7 @@ $nav-item-border: darken($navbar-default-bg, 8%);
 }
 
 #presidium-navigation {
-  .dark & {
-    background: black;
-  }
-
-  background: white;
+  background: var(--background, white);
   min-width: 300px;
   max-width: 600px;
   z-index: $zindex-navbar;

--- a/assets/_sass/components/title-bar/_structure.scss
+++ b/assets/_sass/components/title-bar/_structure.scss
@@ -7,8 +7,8 @@
     height: 48px;
     padding-left: 20px;
     padding-right: 20px;
-    background-color: #ffffff;
-    border-bottom: 1px solid #e5e7eb;
+    background-color: var(--background, #ffffff);
+    border-bottom: 1px solid var(--border, #e5e7eb);
 
     .module-title-bar-brand {
       display: flex;
@@ -30,7 +30,7 @@
       font-size: 1.25rem;
       font-weight: $font-weight-medium;
       margin: 0 1rem 0 0;
-      color: #111827;
+      color: var(--foreground, #111827);
       line-height: 41px;
       // Truncate brand name to prevent layout shift when space is constrained
       overflow: hidden;
@@ -41,9 +41,9 @@
     .quality-category-labels {
       font-size: 11px;
       padding: 2px 8px;
-      border: 1px solid #d1d5db;
+      border: 1px solid var(--border, #d1d5db);
       border-radius: 4px;
-      color: #374151;
+      color: var(--muted-foreground, #374151);
       background-color: transparent;
       font-weight: $font-weight-medium;
       line-height: 1.2;

--- a/assets/_sass/defaults/_default-typography.scss
+++ b/assets/_sass/defaults/_default-typography.scss
@@ -126,7 +126,6 @@ $input-height-base: ($line-height-computed + ($padding-base-vertical * 2) + 2) !
 html,
 body {
   font-family: $primary-font-family !important;
-  color: $primary-font-color !important;
 }
 
 code,


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

[JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-11353)

## What does this PR do?
- Updated general backgrounds and foregrounds to use support dark mode
- Updated some colours to be able to read Isambard CSS variables with a fallback to their default colours
- Updated the title bar to support dark mode
- Removed some aggressive styles which were causing issues by overriding colours across the page

## Why is this change needed?
This change is required for the dark mode implementation

## Dependent PRs
presidium-layouts-base: https://github.com/SPANDigital/presidium-layouts-base/pull/121
presidium-js-enterprise: https://github.com/SPANDigital/presidium-js-enterprise/pull/1508

## How to test
1. Load up the dependent PRs for presidium-layouts-base and presidium-styling-base locally
2. Choose a module (e.g. presidium-docs-internal) and in the `go.mod` file point to your local base files, e.g:
```
module github.com/spandigital/span-handbook-docs

go 1.25

require (
	github.com/spandigital/presidium-layouts-base v0.16.0 // indirect
	github.com/spandigital/presidium-styling-base v0.8.0 // indirect
)
replace github.com/spandigital/presidium-layouts-base => path to your local layouts-base
replace github.com/spandigital/presidium-styling-base => path to your local styling-base

```
3. Load the module with presidium-content-builder
4. Go to presidium-js-enterprise and run `yarn start`

## Screenshots/Video (optional)

https://github.com/user-attachments/assets/bfb7755a-0514-4221-94dd-0eeb1bd7f76c

